### PR TITLE
建築物用途の種別 `-1` を空地とする。

### DIFF
--- a/urban-structure-simulation-arcgis/Simulation/Tool/create_3d_map.py
+++ b/urban-structure-simulation-arcgis/Simulation/Tool/create_3d_map.py
@@ -47,7 +47,7 @@ OTHER_TYPES = (
     454,
     461,
 )
-VALCANT_TYPE = None
+VACANT_TYPES = (None, -1)
 
 # 建築物用途名（詳細塗分け用）
 # シミュレーションの対象ではない用途は変わらないため取り扱わない。（変化なしとなる）
@@ -110,9 +110,9 @@ HEIGHT_FIELDS = [
 
 class UsageChange(Enum):
     UNCHANGED = "変わらない"
-    VALCANT_TO_RESIDENCE = "空地→住宅"
-    VALCANT_TO_OTHER = "空地→住宅以外"
-    TO_VALCANT = "空地になる"
+    VACANT_TO_RESIDENCE = "空地→住宅"
+    VACANT_TO_OTHER = "空地→住宅以外"
+    TO_VACANT = "空地になる"
     RESIDENCE_TO_OTHER = "住宅→住宅以外"
     OTHER_TO_RESIDENCE = "住宅以外→住宅"
     OTHER_TO_OTHER = "住宅以外→住宅以外"
@@ -764,14 +764,14 @@ def compare_usage(obj: Optional[int], sbj: Optional[int]):
     if obj == sbj or (obj in RESIDENCE_TYPES and sbj in RESIDENCE_TYPES):
         return UsageChange.UNCHANGED.value
 
-    if obj == VALCANT_TYPE:
+    if obj in VACANT_TYPES:
         if sbj in RESIDENCE_TYPES:
-            return UsageChange.VALCANT_TO_RESIDENCE.value
+            return UsageChange.VACANT_TO_RESIDENCE.value
         if sbj in OTHER_TYPES:
-            return UsageChange.VALCANT_TO_OTHER.value
+            return UsageChange.VACANT_TO_OTHER.value
 
-    if sbj == VALCANT_TYPE:
-        return UsageChange.TO_VALCANT.value
+    if sbj in VACANT_TYPES:
+        return UsageChange.TO_VACANT.value
 
     if obj in RESIDENCE_TYPES and sbj in OTHER_TYPES:
         return UsageChange.RESIDENCE_TO_OTHER.value

--- a/urban-structure-simulation-arcgis/tests/test_create_3d_map.py
+++ b/urban-structure-simulation-arcgis/tests/test_create_3d_map.py
@@ -16,10 +16,10 @@ def test_get_year():
 
 
 def test_compare_usage():
-    residence = [
+    residences = [
         411,
     ]
-    other = [
+    others = [
         412,
         413,
         414,
@@ -38,22 +38,25 @@ def test_compare_usage():
         454,
         461,
     ]
-    valcant = None
-    for x in residence:
-        assert create_3d_map.compare_usage(valcant, x) == "空地→住宅"
-    for x in other:
-        assert create_3d_map.compare_usage(valcant, x) == "空地→住宅以外"
-    for x in [*residence, *other]:
-        assert create_3d_map.compare_usage(x, valcant) == "空地になる"
-    for x in residence:
-        for y in other:
+    vacants = [None, -1]
+    for vacant in vacants:
+        for x in residences:
+            assert create_3d_map.compare_usage(vacant, x) == "空地→住宅"
+    for vacant in vacants:
+        for x in others:
+            assert create_3d_map.compare_usage(vacant, x) == "空地→住宅以外"
+    for vacant in vacants:
+        for x in [*residences, *others]:
+            assert create_3d_map.compare_usage(x, vacant) == "空地になる"
+    for x in residences:
+        for y in others:
             assert create_3d_map.compare_usage(x, y) == "住宅→住宅以外"
             assert create_3d_map.compare_usage(y, x) == "住宅以外→住宅"
-    for xs in itertools.combinations(other, 2):
+    for xs in itertools.combinations(others, 2):
         assert create_3d_map.compare_usage(*xs) == "住宅以外→住宅以外"
-    for x in [*residence, *other]:
+    for x in [*residences, *others]:
         assert create_3d_map.compare_usage(x, x) == "変わらない"
-    for xs in itertools.combinations(residence, 2):
+    for xs in itertools.combinations(residences, 2):
         assert create_3d_map.compare_usage(*xs) == "変わらない"
 
 


### PR DESCRIPTION
- 建築物用途の種別 `-1` を空地とする。
- typo修正。